### PR TITLE
update docs/_mac/create_bootableusb_mac.md: Correct command execution…

### DIFF
--- a/docs/_mac/create_bootableusb_mac.md
+++ b/docs/_mac/create_bootableusb_mac.md
@@ -14,41 +14,6 @@ diskutil list
 ```
 以下の出力例では /dev/disk8 がUSBメモリ
 ``` bash
-/dev/disk0 (internal, physical):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER 0:      GUID_partition_scheme                        *500.3 GB   disk0 1:             Apple_APFS_ISC Container disk1         524.3 MB   disk0s1
-   2:                 Apple_APFS Container disk3         494.4 GB   disk0s2
-   3:        Apple_APFS_Recovery Container disk2         5.4 GB     disk0s3
-
-/dev/disk3 (synthesized):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-   0:      APFS Container Scheme -                      +494.4 GB   disk3
-                                 Physical Store disk0s2 1:                APFS Volume Macintosh HD            10.7 GB    disk3s1 2:              APFS Snapshot com.apple.os.update-... 10.7 GB    disk3s1s1 3:                APFS Volume Preboot                 6.6 GB     disk3s2
-   4:                APFS Volume Recovery                976.5 MB   disk3s3
-   5:                APFS Volume Data                    148.4 GB   disk3s5
-   6:                APFS Volume VM                      1.1 GB     disk3s6
-
-/dev/disk4 (disk image):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-   0:      GUID_partition_scheme                        +8.6 GB     disk4
-   1:                 Apple_APFS Container disk5         8.6 GB     disk4s1
-
-/dev/disk5 (synthesized):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-   0:      APFS Container Scheme -                      +8.6 GB     disk5
-                                 Physical Store disk4s1
-   1:                APFS Volume iOS 18.0 Simulator B... 8.4 GB     disk5s1
-
-/dev/disk6 (disk image):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-   0:      GUID_partition_scheme                        +19.1 GB    disk6
-   1:                 Apple_APFS Container disk7         19.1 GB    disk6s1
-
-/dev/disk7 (synthesized):
-   #:                       TYPE NAME                    SIZE       IDENTIFIER
-   0:      APFS Container Scheme -                      +19.1 GB    disk7
-                                 Physical Store disk6s1
-   1:                APFS Volume iOS 18.0 Simulator      18.6 GB    disk7s1
-
 /dev/disk8 (external, physical):
    #:                       TYPE NAME                    SIZE       IDENTIFIER
    0:     FDisk_partition_scheme                        *31.0 GB    disk8


### PR DESCRIPTION
## 概要
`docs/_mac/create_bootableusb_mac.md` のコマンド出力結果を修正

## 変更内容
- diskutilコマンド出力結果の不要部分を削除
## 背景・目的
- 目的としてコマンド出力結果例が過剰であったため

## 確認方法
- ブラウザで `/docs/_mac/create_bootableusb_mac.md` を開き、内容が正しく表示されているか確認
- Markdownの構文が崩れていないことを確認

## その他
ご確認よろしくお願いします。